### PR TITLE
GB holidays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changes
 
 * UNRELEASED
-  * Added US calendar
+  * Added US and GB calendars
   * Added brazil/sao-paulo calendar
+  * Now supports a 'forward-only' observance rule where a weekend holiday always gets pushed to Monday
   * Fixed a bug that caused nth-day-of-week holidays in August or September to fail holiday generation
 
 * 0.10.0 - 19Aug22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,21 @@
   * Now supports a 'forward-only' observance rule where a weekend holiday always gets pushed to Monday
   * Fixed a bug that caused nth-day-of-week holidays in August or September to fail holiday generation
 
-* 0.10.0 - 19Aug22
+* 0.10.0 - 19Aug2022
   * Now supports holiday files in subdirectories
   * Improved file generation performance greatly
 
-* 0.9.0 - 9Aug22
+* 0.9.0 - 9Aug2022
   * Generated files now have extensions to avoid collisions with actual namespaces when generating custom jars
 
-* 0.8.0 - 7Aug22
+* 0.8.0 - 7Aug2022
   * Custom build now uses `tools.build`
 
-* 0.7.0 - 7Aug22
+* 0.7.0 - 7Aug2022
   * Now supports singular versions of :days :weeks :months :years and :business-days
   * Cleaned up the namespace, moving internal fns somewhere else to avoid confusion
 
-* 0.6.0 - 7Aug22
+* 0.6.0 - 7Aug2022
   * Goodbye `calenjars`, hello `holi`!
   * The main API function has been simplified greatly: `relative-date-add` is now just `add`
   * Library now ships with the BR calendar, no need to generate anything

--- a/resources/calendars-source/GB.hol
+++ b/resources/calendars-source/GB.hol
@@ -1,5 +1,5 @@
 ; United Kingdom holidays
-New Year's Day|1Jan|observed
+New Year's Day|1Jan|observed-monday
 Good Friday|E-2
 Early May Bank Holiday|1MonMay
 Early May Bank Holiday and VE Day Coincidence|04May2020-

--- a/resources/calendars-source/GB.hol
+++ b/resources/calendars-source/GB.hol
@@ -1,0 +1,13 @@
+; United Kingdom holidays
+New Year's Day|1Jan|observed
+Good Friday|E-2
+Early May Bank Holiday|1MonMay
+Early May Bank Holiday and VE Day Coincidence|04May2020-
+Early May Bank Holiday / VE Day|08May2020
+Spring Bank Holiday|-1MonMay
+Spring Bank Holiday Moved For Jubilee Long Weekend|30May2022-
+Spring Bank Holiday|02Jun2022
+Queen's Platinum Jubilee|03Jun2022
+Queen Elizabeth's Funeral Day|19Sep2022
+Christmas|25Dec|observed-monday-tuesday
+Boxing Day|26Dec|observed-monday-tuesday

--- a/resources/holi-template/examples/GB.hol
+++ b/resources/holi-template/examples/GB.hol
@@ -1,0 +1,13 @@
+; United Kingdom holidays
+New Year's Day|1Jan|observed-monday
+Good Friday|E-2
+Early May Bank Holiday|1MonMay
+Early May Bank Holiday and VE Day Coincidence|04May2020-
+Early May Bank Holiday / VE Day|08May2020
+Spring Bank Holiday|-1MonMay
+Spring Bank Holiday Moved For Jubilee Long Weekend|30May2022-
+Spring Bank Holiday|02Jun2022
+Queen's Platinum Jubilee|03Jun2022
+Queen Elizabeth's Funeral Day|19Sep2022
+Christmas|25Dec|observed-monday-tuesday
+Boxing Day|26Dec|observed-monday-tuesday

--- a/resources/holi-template/examples/SPO.hol
+++ b/resources/holi-template/examples/SPO.hol
@@ -1,4 +1,0 @@
-#include BR
-Aniversário de São Paulo|25Jan
-Revolução Constitucionalista|09Jul
-Dia da Consciência Negra|20Nov

--- a/resources/holi-template/examples/US.hol
+++ b/resources/holi-template/examples/US.hol
@@ -1,0 +1,12 @@
+; United States holidays
+New Year's Day|1Jan|observed
+Martin Luther King Jr. Day|3MonJan
+President's Day|3MonFeb
+Memorial Day|-1MonMay
+Juneteenth|19Jun|observed
+Independence Day|4Jul|observed
+Labor Day|1MonSep
+Columbus Day|2MonOct
+Veterans Day|11Nov|observed
+Thanksgiving|4ThuNov
+Christmas|25Dec|observed

--- a/resources/holi-template/examples/brazil/sao-paulo.hol
+++ b/resources/holi-template/examples/brazil/sao-paulo.hol
@@ -1,0 +1,11 @@
+#include BR
+Aniversário de São Paulo|25Jan
+Revolução Constitucionalista|09Jul
+Dia da Consciência Negra|20Nov
+Antecipação Corpus Christi|11Jun2020-
+Antecipação Corpus Christi|20May2020
+Antecipação Consciência Negra|20Nov2020-
+Antecipação Consciência Negra|21May2020
+Emenda Quarentena|22May2020
+Antecipação Revolução Constitucionalista|09Jul2020-
+Antecipação Revolução Constitucionalista|25May2020

--- a/src/holidays.bnf
+++ b/src/holidays.bnf
@@ -19,7 +19,7 @@ ddmmm = day-31 month-31 | day-30 month-30 | day-feb month-feb
 
 ddmmm-opts = observation-rule? limit-clause? | limit-clause? observation-rule?
 observation-rule = <'|'> observation-rule-option
-<observation-rule-option> = 'observed' | 'observed-monday-tuesday'
+<observation-rule-option> = 'observed' | 'observed-monday' | 'observed-monday-tuesday'
 <limit-clause> = start-year | end-year
 start-year = <'|'> #'\d{4}' <'->'>
 end-year = <'|'> <'->'> #'\d{4}'

--- a/src/luciolucio/holi/types/ddmmm.clj
+++ b/src/luciolucio/holi/types/ddmmm.clj
@@ -20,6 +20,12 @@
         (and (= observation-rule :observed) (= t/SUNDAY (t/day-of-week (:date holiday))))
         (update holiday :date #(t/+ % (t/new-period 1 :days)))
 
+        (and (= observation-rule :observed-monday) (= t/SATURDAY (t/day-of-week (:date holiday))))
+        (update holiday :date #(t/+ % (t/new-period 2 :days)))
+
+        (and (= observation-rule :observed-monday) (= t/SUNDAY (t/day-of-week (:date holiday))))
+        (update holiday :date #(t/+ % (t/new-period 1 :days)))
+
         (and (= observation-rule :observed-monday-tuesday) (contains? #{t/SATURDAY t/SUNDAY} (t/day-of-week (:date holiday))))
         (update holiday :date #(t/+ % (t/new-period 2 :days)))
 

--- a/src/luciolucio/holi/types/expression.clj
+++ b/src/luciolucio/holi/types/expression.clj
@@ -24,6 +24,12 @@
       (and (= observation-rule :observed) (= t/SUNDAY (t/day-of-week (:date holiday))))
       (update holiday :date #(t/+ % (t/new-period 1 :days)))
 
+      (and (= observation-rule :observed-monday) (= t/SATURDAY (t/day-of-week (:date holiday))))
+      (update holiday :date #(t/+ % (t/new-period 2 :days)))
+
+      (and (= observation-rule :observed-monday) (= t/SUNDAY (t/day-of-week (:date holiday))))
+      (update holiday :date #(t/+ % (t/new-period 1 :days)))
+
       (and (= observation-rule :observed-monday-tuesday) (contains? #{t/SATURDAY t/SUNDAY} (t/day-of-week (:date holiday))))
       (update holiday :date #(t/+ % (t/new-period 2 :days)))
 

--- a/test-resources/generate/ddmmm-observed-monday-end-reverse-order.hol
+++ b/test-resources/generate/ddmmm-observed-monday-end-reverse-order.hol
@@ -1,0 +1,1 @@
+New Year's Day|1Jan|->2019|observed-monday

--- a/test-resources/generate/ddmmm-observed-monday-end.hol
+++ b/test-resources/generate/ddmmm-observed-monday-end.hol
@@ -1,0 +1,1 @@
+New Year's Day|1Jan|observed-monday|->2019

--- a/test-resources/generate/ddmmm-observed-monday-start-reverse-order.hol
+++ b/test-resources/generate/ddmmm-observed-monday-start-reverse-order.hol
@@ -1,0 +1,1 @@
+New Year's Day|1Jan|2018->|observed-monday

--- a/test-resources/generate/ddmmm-observed-monday-start.hol
+++ b/test-resources/generate/ddmmm-observed-monday-start.hol
@@ -1,0 +1,1 @@
+New Year's Day|1Jan|observed-monday|2018->

--- a/test-resources/generate/ddmmm-observed-monday.hol
+++ b/test-resources/generate/ddmmm-observed-monday.hol
@@ -1,0 +1,1 @@
+New Year's Day|1Jan|observed-monday

--- a/test-resources/generate/expression-easter-observed-monday-end-reverse-order.hol
+++ b/test-resources/generate/expression-easter-observed-monday-end-reverse-order.hol
@@ -1,0 +1,2 @@
+Easter On Monday|E-1|->2016|observed-monday
+Easter On Monday Again|E+0|->2016|observed-monday

--- a/test-resources/generate/expression-easter-observed-monday-end.hol
+++ b/test-resources/generate/expression-easter-observed-monday-end.hol
@@ -1,0 +1,2 @@
+Easter On Monday|E-1|observed-monday|->2016
+Easter On Monday Again|E+0|observed-monday|->2016

--- a/test-resources/generate/expression-easter-observed-monday-start-reverse-order.hol
+++ b/test-resources/generate/expression-easter-observed-monday-start-reverse-order.hol
@@ -1,0 +1,2 @@
+Easter On Monday|E-1|2015->|observed-monday
+Easter On Monday Again|E+0|2015->|observed-monday

--- a/test-resources/generate/expression-easter-observed-monday-start.hol
+++ b/test-resources/generate/expression-easter-observed-monday-start.hol
@@ -1,0 +1,2 @@
+Easter On Monday|E-1|observed-monday|2015->
+Easter On Monday Again|E+0|observed-monday|2015->

--- a/test-resources/generate/expression-easter-observed-monday.hol
+++ b/test-resources/generate/expression-easter-observed-monday.hol
@@ -1,0 +1,2 @@
+Easter On Monday|E-1|observed-monday
+Easter On Monday Again|E+0|observed-monday

--- a/test/luciolucio/holi/generate_test/holidays_ddmmm_test.clj
+++ b/test/luciolucio/holi/generate_test/holidays_ddmmm_test.clj
@@ -39,6 +39,17 @@
     [{:name "Independence Day" :date (t/date "2020-07-03")}] 2020
     [{:name "Independence Day" :date (t/date "2021-07-05")}] 2021))
 
+(deftest should-generate-holidays-when-holidays-for-year-with-monday-observance-rule-on-ddmmm
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT  "test-resources/generate/ddmmm-observed-monday.hol"))
+    [{:name "New Year's Day" :date (t/date "2016-01-01")}] 2016
+    [{:name "New Year's Day" :date (t/date "2017-01-02")}] 2017
+    [{:name "New Year's Day" :date (t/date "2018-01-01")}] 2018
+    [{:name "New Year's Day" :date (t/date "2019-01-01")}] 2019
+    [{:name "New Year's Day" :date (t/date "2020-01-01")}] 2020
+    [{:name "New Year's Day" :date (t/date "2021-01-01")}] 2021
+    [{:name "New Year's Day" :date (t/date "2022-01-03")}] 2022))
+
 (deftest should-generate-holidays-when-holidays-for-year-with-monday-tuesday-observance-rule-on-ddmmm
   (are [expected year]
        (= expected (gen/holidays-for-year year constants/TEST-ROOT  "test-resources/generate/ddmmm-observed-monday-tuesday.hol"))

--- a/test/luciolucio/holi/generate_test/holidays_ddmmm_test.clj
+++ b/test/luciolucio/holi/generate_test/holidays_ddmmm_test.clj
@@ -105,6 +105,27 @@
     [{:name "Independence Day" :date (t/date "2020-07-03")}] 2020
     [{:name "Independence Day" :date (t/date "2021-07-05")}] 2021))
 
+(deftest should-generate-holidays-when-holidays-for-year-with-monday-observance-rule-and-start-clause-on-ddmmm
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT  "test-resources/generate/ddmmm-observed-monday-start.hol"))
+    [] 2016
+    [] 2017
+    [{:name "New Year's Day" :date (t/date "2018-01-01")}] 2018
+    [{:name "New Year's Day" :date (t/date "2019-01-01")}] 2019
+    [{:name "New Year's Day" :date (t/date "2020-01-01")}] 2020
+    [{:name "New Year's Day" :date (t/date "2021-01-01")}] 2021
+    [{:name "New Year's Day" :date (t/date "2022-01-03")}] 2022)
+
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT  "test-resources/generate/ddmmm-observed-monday-start-reverse-order.hol"))
+    [] 2016
+    [] 2017
+    [{:name "New Year's Day" :date (t/date "2018-01-01")}] 2018
+    [{:name "New Year's Day" :date (t/date "2019-01-01")}] 2019
+    [{:name "New Year's Day" :date (t/date "2020-01-01")}] 2020
+    [{:name "New Year's Day" :date (t/date "2021-01-01")}] 2021
+    [{:name "New Year's Day" :date (t/date "2022-01-03")}] 2022))
+
 (deftest should-generate-holidays-when-holidays-for-year-with-monday-tuesday-observance-rule-and-start-clause-on-ddmmm
   (are [expected year]
        (= expected (gen/holidays-for-year year constants/TEST-ROOT  "test-resources/generate/ddmmm-observed-monday-tuesday-start.hol"))
@@ -158,6 +179,25 @@
     [{:name "Independence Day" :date (t/date "2017-07-04")}] 2017
     [{:name "Independence Day" :date (t/date "2018-07-04")}] 2018
     [{:name "Independence Day" :date (t/date "2019-07-04")}] 2019
+    [] 2020
+    [] 2021))
+
+(deftest should-generate-holidays-when-holidays-for-year-with-monday-observance-rule-and-end-clause-on-ddmmm
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT  "test-resources/generate/ddmmm-observed-monday-end.hol"))
+    [{:name "New Year's Day" :date (t/date "2016-01-01")}] 2016
+    [{:name "New Year's Day" :date (t/date "2017-01-02")}] 2017
+    [{:name "New Year's Day" :date (t/date "2018-01-01")}] 2018
+    [{:name "New Year's Day" :date (t/date "2019-01-01")}] 2019
+    [] 2020
+    [] 2021)
+
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT  "test-resources/generate/ddmmm-observed-monday-end-reverse-order.hol"))
+    [{:name "New Year's Day" :date (t/date "2016-01-01")}] 2016
+    [{:name "New Year's Day" :date (t/date "2017-01-02")}] 2017
+    [{:name "New Year's Day" :date (t/date "2018-01-01")}] 2018
+    [{:name "New Year's Day" :date (t/date "2019-01-01")}] 2019
     [] 2020
     [] 2021))
 

--- a/test/luciolucio/holi/generate_test/holidays_expression_easter_test.clj
+++ b/test/luciolucio/holi/generate_test/holidays_expression_easter_test.clj
@@ -33,6 +33,24 @@
     [{:name "Easter On Monday" :date (t/date "2017-04-17")}] 2017
     [{:name "Easter On Monday" :date (t/date "2018-04-02")}] 2018))
 
+(deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-and-monday-observance-rule
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT "test-resources/generate/expression-easter-observed-monday.hol"))
+    [{:name "Easter On Monday" :date (t/date "2012-04-09")}
+     {:name "Easter On Monday Again" :date (t/date "2012-04-09")}] 2012
+    [{:name "Easter On Monday" :date (t/date "2013-04-01")}
+     {:name "Easter On Monday Again" :date (t/date "2013-04-01")}] 2013
+    [{:name "Easter On Monday" :date (t/date "2014-04-21")}
+     {:name "Easter On Monday Again" :date (t/date "2014-04-21")}] 2014
+    [{:name "Easter On Monday" :date (t/date "2015-04-06")}
+     {:name "Easter On Monday Again" :date (t/date "2015-04-06")}] 2015
+    [{:name "Easter On Monday" :date (t/date "2016-03-28")}
+     {:name "Easter On Monday Again" :date (t/date "2016-03-28")}] 2016
+    [{:name "Easter On Monday" :date (t/date "2017-04-17")}
+     {:name "Easter On Monday Again" :date (t/date "2017-04-17")}] 2017
+    [{:name "Easter On Monday" :date (t/date "2018-04-02")}
+     {:name "Easter On Monday Again" :date (t/date "2018-04-02")}] 2018))
+
 (deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-and-monday-tuesday-observance-rule
   (are [expected year]
        (= expected (gen/holidays-for-year year constants/TEST-ROOT "test-resources/generate/expression-easter-observed-monday-tuesday.hol"))
@@ -86,6 +104,35 @@
     [{:name "Easter On Monday" :date (t/date "2016-03-28")}] 2016
     [{:name "Easter On Monday" :date (t/date "2017-04-17")}] 2017
     [{:name "Easter On Monday" :date (t/date "2018-04-02")}] 2018))
+
+(deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-with-monday-observance-rule-and-start-clause
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT "test-resources/generate/expression-easter-observed-monday-start.hol"))
+    [] 2012
+    [] 2013
+    [] 2014
+    [{:name "Easter On Monday" :date (t/date "2015-04-06")}
+     {:name "Easter On Monday Again" :date (t/date "2015-04-06")}] 2015
+    [{:name "Easter On Monday" :date (t/date "2016-03-28")}
+     {:name "Easter On Monday Again" :date (t/date "2016-03-28")}] 2016
+    [{:name "Easter On Monday" :date (t/date "2017-04-17")}
+     {:name "Easter On Monday Again" :date (t/date "2017-04-17")}] 2017
+    [{:name "Easter On Monday" :date (t/date "2018-04-02")}
+     {:name "Easter On Monday Again" :date (t/date "2018-04-02")}] 2018)
+
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT "test-resources/generate/expression-easter-observed-monday-start-reverse-order.hol"))
+    [] 2012
+    [] 2013
+    [] 2014
+    [{:name "Easter On Monday" :date (t/date "2015-04-06")}
+     {:name "Easter On Monday Again" :date (t/date "2015-04-06")}] 2015
+    [{:name "Easter On Monday" :date (t/date "2016-03-28")}
+     {:name "Easter On Monday Again" :date (t/date "2016-03-28")}] 2016
+    [{:name "Easter On Monday" :date (t/date "2017-04-17")}
+     {:name "Easter On Monday Again" :date (t/date "2017-04-17")}] 2017
+    [{:name "Easter On Monday" :date (t/date "2018-04-02")}
+     {:name "Easter On Monday Again" :date (t/date "2018-04-02")}] 2018))
 
 (deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-with-monday-tuesday-observance-rule-and-start-clause
   (are [expected year]
@@ -148,6 +195,37 @@
     [{:name "Easter On Monday" :date (t/date "2014-04-21")}] 2014
     [{:name "Easter On Monday" :date (t/date "2015-04-06")}] 2015
     [{:name "Easter On Monday" :date (t/date "2016-03-28")}] 2016
+    [] 2017
+    [] 2018))
+
+(deftest should-generate-holidays-when-holidays-for-year-with-easter-expression-with-monday-observance-rule-and-end-clause
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT "test-resources/generate/expression-easter-observed-monday-end.hol"))
+    [{:name "Easter On Monday" :date (t/date "2012-04-09")}
+     {:name "Easter On Monday Again" :date (t/date "2012-04-09")}] 2012
+    [{:name "Easter On Monday" :date (t/date "2013-04-01")}
+     {:name "Easter On Monday Again" :date (t/date "2013-04-01")}] 2013
+    [{:name "Easter On Monday" :date (t/date "2014-04-21")}
+     {:name "Easter On Monday Again" :date (t/date "2014-04-21")}] 2014
+    [{:name "Easter On Monday" :date (t/date "2015-04-06")}
+     {:name "Easter On Monday Again" :date (t/date "2015-04-06")}] 2015
+    [{:name "Easter On Monday" :date (t/date "2016-03-28")}
+     {:name "Easter On Monday Again" :date (t/date "2016-03-28")}] 2016
+    [] 2017
+    [] 2018)
+
+  (are [expected year]
+       (= expected (gen/holidays-for-year year constants/TEST-ROOT "test-resources/generate/expression-easter-observed-monday-end-reverse-order.hol"))
+    [{:name "Easter On Monday" :date (t/date "2012-04-09")}
+     {:name "Easter On Monday Again" :date (t/date "2012-04-09")}] 2012
+    [{:name "Easter On Monday" :date (t/date "2013-04-01")}
+     {:name "Easter On Monday Again" :date (t/date "2013-04-01")}] 2013
+    [{:name "Easter On Monday" :date (t/date "2014-04-21")}
+     {:name "Easter On Monday Again" :date (t/date "2014-04-21")}] 2014
+    [{:name "Easter On Monday" :date (t/date "2015-04-06")}
+     {:name "Easter On Monday Again" :date (t/date "2015-04-06")}] 2015
+    [{:name "Easter On Monday" :date (t/date "2016-03-28")}
+     {:name "Easter On Monday Again" :date (t/date "2016-03-28")}] 2016
     [] 2017
     [] 2018))
 

--- a/test/luciolucio/holi/generate_test/holidays_locations_test.clj
+++ b/test/luciolucio/holi/generate_test/holidays_locations_test.clj
@@ -56,7 +56,39 @@
                {:name "Columbus Day" :date (t/date "2022-10-10")}
                {:name "Veterans Day" :date (t/date "2022-11-11")}
                {:name "Thanksgiving" :date (t/date "2022-11-24")}
-               {:name "Christmas" :date (t/date "2022-12-26")}]))
+               {:name "Christmas" :date (t/date "2022-12-26")}]
+    "GB" 2019 [{:name "New Year's Day" :date (t/date "2019-01-01")}
+               {:name "Good Friday" :date (t/date "2019-04-19")}
+               {:name "Early May Bank Holiday" :date (t/date "2019-05-06")}
+               {:name "Spring Bank Holiday" :date (t/date "2019-05-27")}
+               {:name "Christmas" :date (t/date "2019-12-25")}
+               {:name "Boxing Day" :date (t/date "2019-12-26")}]
+    "GB" 2020 [{:name "New Year's Day" :date (t/date "2020-01-01")}
+               {:name "Good Friday" :date (t/date "2020-04-10")}
+               {:name "Early May Bank Holiday / VE Day" :date (t/date "2020-05-08")}
+               {:name "Spring Bank Holiday" :date (t/date "2020-05-25")}
+               {:name "Christmas" :date (t/date "2020-12-25")}
+               {:name "Boxing Day" :date (t/date "2020-12-28")}]
+    "GB" 2021 [{:name "New Year's Day" :date (t/date "2021-01-01")}
+               {:name "Good Friday" :date (t/date "2021-04-02")}
+               {:name "Early May Bank Holiday" :date (t/date "2021-05-03")}
+               {:name "Spring Bank Holiday" :date (t/date "2021-05-31")}
+               {:name "Christmas" :date (t/date "2021-12-27")}
+               {:name "Boxing Day" :date (t/date "2021-12-28")}]
+    "GB" 2022 [{:name "New Year's Day" :date (t/date "2022-01-03")}
+               {:name "Good Friday" :date (t/date "2022-04-15")}
+               {:name "Early May Bank Holiday" :date (t/date "2022-05-02")}
+               {:name "Spring Bank Holiday" :date (t/date "2022-06-02")}
+               {:name "Queen's Platinum Jubilee" :date (t/date "2022-06-03")}
+               {:name "Queen Elizabeth's Funeral Day" :date (t/date "2022-09-19")}
+               {:name "Christmas" :date (t/date "2022-12-27")}
+               {:name "Boxing Day" :date (t/date "2022-12-26")}]
+    "GB" 2023 [{:name "New Year's Day" :date (t/date "2023-01-02")}
+               {:name "Good Friday" :date (t/date "2023-04-07")}
+               {:name "Early May Bank Holiday" :date (t/date "2023-05-01")}
+               {:name "Spring Bank Holiday" :date (t/date "2023-05-29")}
+               {:name "Christmas" :date (t/date "2023-12-25")}
+               {:name "Boxing Day" :date (t/date "2023-12-26")}]))
 
 (deftest should-generate-holidays-when-holidays-for-year-with-specific-cities
   (are [city-name year expected]


### PR DESCRIPTION
* Added US and GB calendars
* Added brazil/sao-paulo calendar
* Now supports a 'forward-only' observance rule where a weekend holiday always gets pushed to Monday
* Fixed a bug that caused nth-day-of-week holidays in August or September to fail holiday generation